### PR TITLE
remove -l option for rconnector

### DIFF
--- a/scripts_RAD/discoRAD_finalization.sh
+++ b/scripts_RAD/discoRAD_finalization.sh
@@ -65,7 +65,7 @@ discofile=${original_disco}_simpler
 ls ${discofile}.fa > ${discofile}.fof
 
 # Compute sequence similarities
-cmd="${short_read_connector_directory}/short_read_connector.sh -b ${discofile}.fa -q ${discofile}.fof -s 0 -k ${usedk} -a 1 -l -p ${discofile}" 
+cmd="${short_read_connector_directory}/short_read_connector.sh -b ${discofile}.fa -q ${discofile}.fof -s 0 -k ${usedk} -a 1 -p ${discofile}" 
 echo -e "\t\t$cmd"
 $cmd
 
@@ -110,7 +110,7 @@ for type in 'raw' 'filtered'
     done
 
 # Clean results
-for type in 'raw' 'filtered' 
+for type in 'raw' 'filtered'
 do
     cmd="mv "$type"_${original_disco}_with_sorted_formatted_clusters.vcf "$type"_${rawdiscofile_base}_sorted_with_clusters.vcf"
     echo -e "\t\t$cmd"


### PR DESCRIPTION
It seems short_read_connector.sh has no -l option (1.1.0).

```
short_read_connector.sh: illegal option -- l
Invalid option: -
```

The result is a missing file for the quick_hierarchical_clustering (next step) that tries to parse the file forever with 100% CPU.